### PR TITLE
Fix OSX compilation error. 

### DIFF
--- a/Framework/Source/Ensemble/CDEPersistentStoreEnsemble.m
+++ b/Framework/Source/Ensemble/CDEPersistentStoreEnsemble.m
@@ -117,7 +117,7 @@ static NSString * const kCDEIdentityTokenContext = @"kCDEIdentityTokenContext";
     self.eventIntegrator.didSaveBlock = ^(NSManagedObjectContext *context, NSDictionary *info) {
         CDEPersistentStoreEnsemble *strongSelf = weakSelf;
         if ([strongSelf.delegate respondsToSelector:@selector(persistentStoreEnsemble:didSaveMergeChangesWithNotification:)]) {
-            NSNotification *notification = [[NSNotification alloc] initWithName:NSManagedObjectContextDidSaveNotification object:context userInfo:info];
+            NSNotification *notification = [NSNotification notificationWithName:NSManagedObjectContextDidSaveNotification object:context userInfo:info];
             [strongSelf.delegate persistentStoreEnsemble:strongSelf didSaveMergeChangesWithNotification:notification];
         }
     };


### PR DESCRIPTION
NSNotification -initWithName:object:userInfo is not available in OSX 10.8 SDK or earlier.

Changed to use +notificationWithName:object:userInfo instead , which works both on iOS and OSX
