### PR TITLE
Suppressing warning: Incompatible pointer types initializing 'NSString *...

### DIFF
--- a/Framework/Source/Events/CDEEventStore.m
+++ b/Framework/Source/Events/CDEEventStore.m
@@ -45,7 +45,7 @@ static NSString *defaultPathToEventDataRootDirectory = nil;
 {
     if ([CDEEventStore class] == self) {
         NSArray *urls = [[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask];
-        NSString *appSupportDir = [urls.lastObject path];
+        NSString *appSupportDir = [(NSURL *)urls.lastObject path];
         NSString *path = [appSupportDir stringByAppendingPathComponent:[[NSBundle mainBundle] bundleIdentifier]];
         path = [path stringByAppendingPathComponent:@"com.mentalfaculty.ensembles.eventdata"];
         [self setDefaultPathToEventDataRootDirectory:path];


### PR DESCRIPTION
...__strong' with an expression of type 'CGPathRef' (aka 'const struct CGPath *')
