### PR TITLE
Remove the identityToken KVO observer from the cloudFileSystem on dealloc

### DIFF
--- a/Framework/Source/Ensemble/CDEPersistentStoreEnsemble.m
+++ b/Framework/Source/Ensemble/CDEPersistentStoreEnsemble.m
@@ -134,6 +134,8 @@ NSString * const CDEMonitoredManagedObjectContextDidSaveNotification = @"CDEMoni
 
 - (void)dealloc
 {
+    [(id)self.cloudFileSystem removeObserver:self forKeyPath:@"identityToken"];
+
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [saveMonitor stopMonitoring];
 }


### PR DESCRIPTION
This prevents a potential invalid-object access and squelches a run-time warning.
