### PR TITLE
Less magic numbers mark II

### DIFF
--- a/Framework/Ensembles iOS.xcodeproj/project.pbxproj
+++ b/Framework/Ensembles iOS.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 		07D2D63A182D6846001D24BC /* NSManagedObjectModel+CDEAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObjectModel+CDEAdditions.m"; sourceTree = "<group>"; };
 		07D2D63F182D6887001D24BC /* CDEManagedObjectModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDEManagedObjectModelTests.m; sourceTree = "<group>"; };
 		07F001BD18427645001A0504 /* IntegratorMergeTestsFixture.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = IntegratorMergeTestsFixture.json; sourceTree = "<group>"; };
+		34700E9D188B225700FD00B1 /* CDEAvailabilityMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDEAvailabilityMacros.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -462,6 +463,7 @@
 				07BF379017F1853000C56F64 /* CDEAsynchronousTaskQueue.m */,
 				07BF379117F1853000C56F64 /* CDEDefines.h */,
 				07BF379217F1853000C56F64 /* CDEDefines.m */,
+				34700E9D188B225700FD00B1 /* CDEAvailabilityMacros.h */,
 				07BF379317F1853000C56F64 /* CDEFoundationAdditions.h */,
 				07BF379417F1853000C56F64 /* CDEFoundationAdditions.m */,
 				07BF379517F1853000C56F64 /* CoreDataEnsembles.h */,

--- a/Framework/Source/Cloud File Systems/CDEICloudFileSystem.m
+++ b/Framework/Source/Cloud File Systems/CDEICloudFileSystem.m
@@ -9,6 +9,7 @@
 #import "CDEICloudFileSystem.h"
 #import "CDECloudDirectory.h"
 #import "CDECloudFile.h"
+#import "CDEAvailabilityMacros.h"
 
 @implementation CDEICloudFileSystem {
     NSFileManager *fileManager;
@@ -186,6 +187,7 @@
     
     // Determine downloading key and set the appropriate predicate. This is OS dependent.
     NSPredicate *metadataPredicate = nil;
+
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0) && (__MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_9)
     metadataPredicate = [NSPredicate predicateWithFormat:@"%K = FALSE AND %K = FALSE AND %K ENDSWITH '.cdeevent' AND %K BEGINSWITH %@",
                          NSMetadataUbiquitousItemIsDownloadedKey, NSMetadataUbiquitousItemIsDownloadingKey, NSMetadataItemFSNameKey, NSMetadataItemPathKey, rootDirectoryURL.path];

--- a/Framework/Source/General/CDEAvailabilityMacros.h
+++ b/Framework/Source/General/CDEAvailabilityMacros.h
@@ -1,0 +1,7 @@
+#ifndef __IPHONE_7_0
+    #define __IPHONE_7_0     70000
+#endif
+
+#ifndef __MAC_10_9
+    #define __MAC_10_9      1090
+#endif


### PR DESCRIPTION
You're right that those macros fail on older SDKs.  It's better to use the named #define than a magic number, though; I've added CDEAvailabilityMacros.h which checks for the #define and declares it as needed.
