### PR TITLE
Do not include sub-entities when fetching unreferenced objects.

### DIFF
--- a/Framework/Source/Events/CDEEventIntegrator.m
+++ b/Framework/Source/Events/CDEEventIntegrator.m
@@ -451,6 +451,7 @@
     [managedObjectContext performBlockAndWait:^{
         [objectIDsByEntity enumerateKeysAndObjectsUsingBlock:^(NSString *entityName, NSSet *objectIDs, BOOL *stop) {
             NSFetchRequest *fetch = [NSFetchRequest fetchRequestWithEntityName:entityName];
+            fetch.includesSubentities = NO;
             fetch.predicate = [NSPredicate predicateWithFormat:@"NOT (SELF IN %@)", objectIDs];
             NSError *error;
             NSArray *unreferencedObjects = [managedObjectContext executeFetchRequest:fetch error:&error];


### PR DESCRIPTION
This is to fix a bug where an object belonging to a sub-entity would be fetched _and_ matched by the predicate since it is logically not in the object IDs set. The object would thus be deleted being seen as unreferenced.

Issue #118
