### PR TITLE
Update Ensembles.podspec

### DIFF
--- a/Ensembles.podspec
+++ b/Ensembles.podspec
@@ -52,8 +52,8 @@ Pod::Spec.new do |s|
     ss.dependency 'SSZipArchive'
     ss.framework = 'MultipeerConnectivity'
     ss.source_files = 'Framework/Extensions/CDEMultipeerCloudFileSystem.{h,m}'
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.10'
+    ss.ios.deployment_target = '7.0'
+    ss.osx.deployment_target = '10.10'
   end
   
   s.subspec 'Node' do |ss|


### PR DESCRIPTION
Set ios.deployment_target = '7.0' and osx.deployment_target = '10.10' on the `Multipeer` subspace, not on the main spec.  This was forcing iOS 7 or OS X 10.10, while the primary spec requires only iOS 6.0 or OS X 10.7.  (The README suggests iOS 7 and OS X 10.9 are the desired minimums; this change still applies, but the targets should be set if needed in lines 24 & 25).
