### PR TITLE
Added checks for transient properties

### DIFF
--- a/Framework/Tests/CDEBaseliningSyncTests.m
+++ b/Framework/Tests/CDEBaseliningSyncTests.m
@@ -140,7 +140,7 @@
     NSArray *parents = [context1 executeFetchRequest:[NSFetchRequest fetchRequestWithEntityName:@"Parent"] error:NULL];
     for (NSInteger i = 0; i < 6; i++) {
         for (id parent in parents) {
-            [parent setValue:@"tom" forKey:@"name"];
+            [parent setValue:[NSString stringWithFormat:@"tom%i", arc4random()] forKey:@"name"];
         }
         XCTAssertTrue([context1 save:NULL], @"Could not save");
     }
@@ -192,7 +192,7 @@
     NSArray *parents = [context1 executeFetchRequest:[NSFetchRequest fetchRequestWithEntityName:@"Parent"] error:NULL];
     for (NSInteger i = 0; i < 11; i++) {
         for (id parent in parents) {
-            [parent setValue:@"tom" forKey:@"name"];
+            [parent setValue:[NSString stringWithFormat:@"tom%i", arc4random()] forKey:@"name"];
         }
         XCTAssertTrue([context1 save:NULL], @"Could not save");
     }


### PR DESCRIPTION
As I mentioned, I'm using transient properties quite a lot in my app, which are causing lots of empty events, when the context is saved. This change discards empty changes.

Some unit tests are not working right now, because this change is reducing the number of events in some cases. I haven't had the time to check each test yet, but maybe you can give me a hint if I'm on the right track here ;)