### PR TITLE
Ignore NSFetchedPropertyDescription

### DIFF
--- a/Framework/Source/Events/CDEPropertyChangeValue.m
+++ b/Framework/Source/Events/CDEPropertyChangeValue.m
@@ -28,6 +28,11 @@
     
     for (NSString *propertyName in names) {
         NSPropertyDescription *propertyDesc = entity.propertiesByName[propertyName];
+        
+        if ([propertyDesc isKindOfClass:[NSFetchedPropertyDescription class]]) {
+            continue;
+        }
+        
         CDEPropertyChangeValue *change = [[CDEPropertyChangeValue alloc] initWithObject:object propertyDescription:propertyDesc eventStore:newEventStore isPreSave:isPreSave storeValues:storeValues];
         [propertyChanges addObject:change];
     }


### PR DESCRIPTION
NSFetchedPropertyDescription are read-only, and thus should be ignored.