### PR TITLE
Support for Core Data changes on iOS 11

### DIFF
--- a/Framework/Source/Events/CDEEventMigrator.m
+++ b/Framework/Source/Events/CDEEventMigrator.m
@@ -157,10 +157,17 @@ static NSString *kCDEDefaultStoreType;
                     NSDictionary *metadata = [NSPersistentStoreCoordinator metadataForPersistentStoreOfType:nil URL:fileURL error:&error];
                     NSString *storeType = metadata[NSStoreTypeKey];
                     if (!storeType) @throw [[NSException alloc] initWithName:CDEException reason:@"" userInfo:nil];
-                    
-#warning Using hard coded string here to get around problems in Xcode 9 Beta. Replace this with constant in final release
-                    NSDictionary *options = @{NSMigratePersistentStoresAutomaticallyOption: @YES, NSInferMappingModelAutomaticallyOption: @YES, @"_NSBinaryStoreInsecureDecodingCompatibilityOption": @YES};
+                  
+                    NSDictionary *options = nil;
+                    if (@available(iOS 11.0, *)) {
+                        options = @{NSMigratePersistentStoresAutomaticallyOption: @YES, NSInferMappingModelAutomaticallyOption: @YES, NSBinaryStoreInsecureDecodingCompatibilityOption: @YES};
+                    } else {
+                        // Fallback on earlier versions
+                        options = @{NSMigratePersistentStoresAutomaticallyOption: @YES, NSInferMappingModelAutomaticallyOption: @YES};
+                    }
+                  
                     fileStore = [importContext.persistentStoreCoordinator addPersistentStoreWithType:storeType configuration:nil URL:fileURL options:options error:&error];
+                  
                     if (!fileStore) @throw [[NSException alloc] initWithName:CDEException reason:@"" userInfo:nil];
                     
                     BOOL success = [self migrateObjectsInContext:importContext toContext:self.eventStore.managedObjectContext error:&error];

--- a/Framework/Tests/CDEBaseliningSyncTests.m
+++ b/Framework/Tests/CDEBaseliningSyncTests.m
@@ -355,7 +355,12 @@
     NSManagedObjectModel *eventModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
     NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:eventModel];
     baselineContext.persistentStoreCoordinator = coordinator;
-    NSDictionary *options = @{@"_NSBinaryStoreInsecureDecodingCompatibilityOption": @YES};
+    NSDictionary *options = nil;
+  
+    if (@available(iOS 11.0, *)) {
+        options = @{NSBinaryStoreInsecureDecodingCompatibilityOption: @YES};
+    }
+  
     NSPersistentStore *store = [coordinator addPersistentStoreWithType:NSBinaryStoreType configuration:nil URL:baselineURL options:options error:NULL];
     XCTAssertNotNil(store, @"Store was nil");
     return baselineContext;

--- a/Framework/Tests/CDEEventMigratorTests.m
+++ b/Framework/Tests/CDEEventMigratorTests.m
@@ -115,7 +115,12 @@
     NSURL *url = [NSURL fileURLWithPath:exportedEventsFile];
     NSManagedObjectModel *model = self.eventStore.managedObjectContext.persistentStoreCoordinator.managedObjectModel;
     NSPersistentStoreCoordinator *psc = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
-    NSDictionary *options = @{@"_NSBinaryStoreInsecureDecodingCompatibilityOption" : @YES};
+    NSDictionary *options = nil;
+  
+    if (@available(iOS 11.0, *)) {
+        options = @{NSBinaryStoreInsecureDecodingCompatibilityOption: @YES};
+    }
+    
     [psc addPersistentStoreWithType:NSBinaryStoreType configuration:nil URL:url options:options error:NULL];
     NSManagedObjectContext *newContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
     newContext.persistentStoreCoordinator = psc;


### PR DESCRIPTION
Workaround for binary store changes on iOS 11. A better way to do this
should be using NSBinaryStoreSecureDecodingClasses option in the future.