### PR TITLE
Multipeer file retrieval response for no new files

### DIFF
--- a/Framework/Extensions/CDEMultipeerCloudFileSystem.h
+++ b/Framework/Extensions/CDEMultipeerCloudFileSystem.h
@@ -15,6 +15,7 @@ extern NSString * const CDEMultipeerCloudFileSystemDidImportFilesNotification;
 
 @optional
 - (void)newDataWasAddedOnPeerWithID:(id <NSObject, NSCopying, NSCoding>)peerID;
+- (void)fileRetrievalRequestCompletedWithNoFilesFromPeerWithID:(id <NSObject, NSCopying, NSCoding>)peerID;
 
 @required
 - (BOOL)sendData:(NSData *)data toPeerWithID:(id <NSObject, NSCopying, NSCoding>)peerID;


### PR DESCRIPTION
This PR addresses #268. 

I noticed that the message type `CDEMultipeerMessageTypeFileRetrievalResponse` was going unused in the entire project, so I re-named and repurposed it to `CDEMultipeerMessageTypeFileRetrievalResponseNoFiles` to send back in the case where there are no files to be sent back. I've also added another optional method on `CDEMultipeerConnection` to handle this response.